### PR TITLE
Switch to using locations to avoid block loading in EffFakeMultiBlockChange

### DIFF
--- a/Main/src/main/java/poa/poaskrewritev2/effects/EffFakeMultiBlockChange.java
+++ b/Main/src/main/java/poa/poaskrewritev2/effects/EffFakeMultiBlockChange.java
@@ -19,38 +19,40 @@ import java.util.Map;
 public class EffFakeMultiBlockChange extends Effect {
 
     static {
-        Skript.registerEffect(EffFakeMultiBlockChange.class, "fake multi block set %blocks% as %blockdata% for %players%");
+        Skript.registerEffect(EffFakeMultiBlockChange.class, "fake multi block set %locations% (as|to) %blockdata% for %players%");
     }
 
-    private Expression<Block> blocks;
+    private Expression<Location> locations;
     private Expression<BlockData> blockData;
     private Expression<Player> players;
 
     @SuppressWarnings({"unchecked", "NullableProblems"})
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
-        blocks = (Expression<Block>) exprs[0];
+        locations = (Expression<Location>) exprs[0];
         blockData = (Expression<BlockData>) exprs[1];
         players = (Expression<Player>) exprs[2];
         return true;
     }
 
     @Override
-    protected void execute(Event e) {
-        BlockData blockData = this.blockData.getSingle(e);
+    protected void execute(Event event) {
+        BlockData blockData = this.blockData.getSingle(event);
         if (blockData == null) return;
 
         Map<Location, BlockData> map = new HashMap<>();
-        for (Block block : blocks.getArray(e))
-            map.put(block.getLocation(), blockData);
+        for (Location location : locations.getArray(event))
+            map.put(location, blockData);
+        
+        if (map.isEmpty()) return;
 
-        for (Player player : players.getArray(e))
+        for (Player player : players.getArray(event))
             player.sendMultiBlockChange(map, false);
     }
 
     @Override
     public @NotNull String toString(@Nullable Event event, boolean debug) {
-        String blocks = this.blocks.toString(event, debug);
+        String blocks = this.locations.toString(event, debug);
         String data = this.blockData.toString(event, debug);
         String players = this.players.toString(event, debug);
         return "fake multi block set " + blocks + " as " + data + " for " + players;


### PR DESCRIPTION
Using locations instead of blocks means the user doesn't need to fetch thousands of blocks they don't need to know about, and can rather use locations directly, saving a lot of performance. This should be backwards compatible, too, as blocks can be converted to locations.